### PR TITLE
gevent: support v1.5+, removing support for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.5-dev" # 3.5 development branch
   - "3.6"

--- a/easypy/concurrency.py
+++ b/easypy/concurrency.py
@@ -454,9 +454,11 @@ class Futures(list):
         """
         frames = dict(iter_thread_frames())
         for i, future in enumerate(futures, 1):
+            thread_ident = future.ctx['thread_ident']
             try:
-                frame = frames[future.ctx['thread_ident']]
+                frame = frames[thread_ident]
             except KeyError:
+                assert False, frames
                 frame = None  # this might happen in race-conditions with a new thread starting
             if not verbose or not frame:
                 if frame:

--- a/easypy/gevent.py
+++ b/easypy/gevent.py
@@ -39,8 +39,6 @@ def apply_patch(hogging_detection=False, real_threads=1):
     import gevent
     import gevent.monkey
 
-    assert gevent.version_info < (1, 5), "easpy does not yet support gevent 1.5"
-
     for m in ["easypy.threadtree", "easypy.concurrency"]:
         assert m not in sys.modules, "Must apply the gevent patch before importing %s" % m
 


### PR DESCRIPTION
apparently the `thread._greenlet` attribute was removed, so we have to
keep track of thread->greenlet matching ourselves