### PR TITLE
Use inspect.signature instead of getargspec

### DIFF
--- a/easypy/collections.py
+++ b/easypy/collections.py
@@ -34,8 +34,8 @@ if sys.version_info[:2] >= (3, 5):
 
 
 def _format_predicate(pred):
-    args = inspect.formatargspec(*inspect.getargspec(pred))
-    return "<lambda>" if pred.__name__ == "<lambda>" else "{pred.__name__}{args}".format(**locals())
+    signature = inspect.signature(pred)
+    return "<lambda>" if pred.__name__ == "<lambda>" else f"{pred.__name__}{signature}"
 
 
 def _format_filter_string(preds, filters):


### PR DESCRIPTION
Transition from using the deprecated `inspect.getargspec` and `inspect.formatargspec` functions, as recommended in the  [`inspect.formatargspec` documentation](https://docs.python.org/3.8/library/inspect.html#inspect.formatargspec):

> Deprecated since version 3.5: Use [signature()](https://docs.python.org/3.8/library/inspect.html#inspect.signature) and [Signature Object](https://docs.python.org/3.8/library/inspect.html#inspect-signature-object), which provide a better introspecting API for callables.

I reproduced and replicated the results in old python (3.8) and newer python with the fixes:
```pycon
In [1]: from easypy.collections import ListCollection
In [2]: from easypy.bunch import Bunch
In [3]: lst_collection = ListCollection((Bunch(name='michael'), Bunch(name='ofer')))
In [4]: def foo(b):
   ...:     return b.name.startswith('x')
   ...: 
In [5]: lst_collection.filtered(foo)
<Filtered collection based on an anonymous 'ListCollection' (foo(b))>
In [6]: lst_collection.choose(foo)
---------------------------------------------------------------------------
ObjectNotFound                            Traceback (most recent call last)
Cell In[6], line 1
----> 1 lst_collection.choose(foo)
File ~/Developer/easypy/easypy/collections.py:349, in ObjectCollectionBase.choose(self, *preds, **filters)
    347 for obj in self.iter_filtered(_shuffle=True, *preds, **filters):
    348     return obj
--> 349 raise ObjectNotFound(self, preds, filters)
ObjectNotFound: Object not found in ListCollection([Bunch(name='michael'), Bunch(name='ofer')], size=2), filtered by foo(b)
    collection = ListCollection([Bunch(name='michael'), Bunch(name='ofer')], size=2)
    timestamp = 2025-07-21T16:33:28.765688
```

This code affects `FilteredCollection.__repr__` and `ObjectNotFound` errors. In both cases, we can see the proper representation of the filter: `foo(b)`